### PR TITLE
Change min levels and hand edits at Persian Gulf

### DIFF
--- a/edit_025deg_topog_new_fillfraction.txt
+++ b/edit_025deg_topog_new_fillfraction.txt
@@ -20,3 +20,14 @@ editTopo.py edits file version 1
   1056  632  5.062045574188232  0.0
   1056  633  5.062045574188232  0.0
   1057  633  5.062045574188232  0.0
+# 
+# Edits to remove some wet points on Persian Gulf and Red sea https://github.com/COSIMA/access-om3/issues/286
+# created: Thu Mar 13 12:26:31 2025
+# by: ek4684
+# via: bathymetry-tools/editTopo.py topog.nc
+#
+#    i    j  old                 new
+  1322  660  11.739693641662598  0.0
+  1322  661  12.747864723205566  0.0
+  1322  662  11.92029857635498   0.0
+  1321  662  6.958303928375244   0.0

--- a/gen_topo.sh
+++ b/gen_topo.sh
@@ -53,7 +53,7 @@ python ./bathymetry-tools/editTopo.py --overwrite --nogui --apply edit_025deg_to
 ./bathymetry-tools/bin/topogtools deseas -i topog_new_fillfraction_edited.nc -o topog_new_fillfraction_edited_deseas.nc --grid_type C
 
 # Set maximum/minimum depth
-./bathymetry-tools/bin/topogtools min_max_depth -i topog_new_fillfraction_edited_deseas.nc -o topog_new_fillfraction_edited_deseas_mindepth.nc --level 4 --vgrid ocean_vgrid.nc --vgrid_type mom6
+./bathymetry-tools/bin/topogtools min_max_depth -i topog_new_fillfraction_edited_deseas.nc -o topog_new_fillfraction_edited_deseas_mindepth.nc --level 7 --vgrid ocean_vgrid.nc --vgrid_type mom6
 
 # Name final topog as topo.nc
 cp topog_new_fillfraction_edited_deseas_mindepth.nc topog.nc


### PR DESCRIPTION
This PR edits the topography near Persian Gulf to address extreme salinity [issues](https://github.com/COSIMA/access-om3/issues/286#issuecomment-2716781082) and set the minimum depth to level 7 (~10.43m) globally, to be consistent with OM2 and GFDL configurations. 

Following edits were made:

```
#    i    j  old                 new
  1322  660  11.739693641662598  0.0
  1322  661  12.747864723205566  0.0
  1322  662  11.92029857635498   0.0
  1321  662  6.958303928375244   0.0
 ``` 
<img width="455" alt="Screenshot 2025-03-13 at 12 36 42 pm" src="https://github.com/user-attachments/assets/1e6781d6-c293-4c9e-8633-894ab122fbc4" />
