### PR TITLE
hard-wire inputs in gen_topo.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Makes 0.25-degree (25km) `topog.nc` MOM6 global bathymetry file for [ACCESS-OM3-
    qsub gen_topo.sh
    ```
 
-3. **Finalize Output Files:**
+3. **Finalise Output Files:**
    Once the output files meet your satisfaction, commit and push the changes, then run `finalise.sh` to add the git commit hash as metadata in the output `.nc` files for provenance.
 
 ## Note on Dependencies  

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # make_OM3_025deg_topo
 
-Make 0.25-degree `topog.nc` MOM bathymetry file from the GEBCO 2024 dataset.
+Makes 0.25-degree (25km) `topog.nc` MOM6 global bathymetry file for [ACCESS-OM3-25km](https://github.com/ACCESS-NRI/access-om3-configs/tree/release-MC_25km_jra_iaf), based on the GEBCO 2024 dataset.
 
 ## Workflow Overview
 
-1. **Generate Topography:**  
-   Use `./gen_topog.sh` to generate the topography and associated files. For 0.25-degree resolution or higher, this will require submission via `qsub`.
-
-   First, add gdata for your project & working directory to the `#PBS -l storage=` line in `get_topo.sh`
-
-   Then, use the `qsub` command to submit the script, passing the required input files as arguments. For example:  
+1. **Download to Gadi**
+   This repository contains submodules, so clone with
    ```bash
-   qsub -v INPUT_HGRID="/path/to/ocean_hgrid.nc",INPUT_VGRID="/path/to/ocean_vgrid.nc",INPUT_GBCO="/path/to/GEBCO_2024.nc" -P $PROJECT gen_topo.sh
+   git clone --recursive https://github.com/ACCESS-NRI/make_OM3_025deg_topo.git
    ```
 
-2. **Finalize Output Files:**  
-   Once the output files meet your satisfaction, commit and push the changes, then add the git commit hash as metadata in the output `.nc` files by running `finalise.sh`.
+2. **Generate Topography:**
+   Use `./gen_topog.sh` to generate the topography and associated files. For 0.25-degree resolution or higher, this will require submission via `qsub`.
+
+   - add gdata for your project & working directory to the `#PBS -l storage=` line in `gen_topo.sh`.
+   - check/adjust `INPUT_HGRID`, `INPUT_VGRID` and `INPUT_GEBCO` in `gen_topo.sh`.
+   - use the `qsub` command to submit the script:
+   ```bash
+   qsub gen_topo.sh
+   ```
+
+3. **Finalize Output Files:**
+   Once the output files meet your satisfaction, commit and push the changes, then run `finalise.sh` to add the git commit hash as metadata in the output `.nc` files for provenance.
 
 ## Note on Dependencies  
 
 This workflow relies on the **xp65 conda environments** for running the scripts and generating the outputs. As long as you are a member of the _xp65_ project, this conda environment is loaded as part of the scripts.
-
---- 
-
-```bash
-qsub -v INPUT_HGRID=/g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/mosaic/global.025deg/2025.01.30/ocean_hgrid.nc,INPUT_VGRID=/g/data/vk83/prerelease/configurations/inputs/access-om3/mom/grids/vertical/global.025deg/2025.01.30/ocean_vgrid.nc,INPUT_GBCO=/g/data/ik11/inputs/GEBCO_2024/GEBCO_2024.nc -P $PROJECT gen_topo.sh
-```

--- a/gen_topo.sh
+++ b/gen_topo.sh
@@ -7,12 +7,14 @@
 #PBS -l wd
 #PBS -l storage=gdata/ik11+gdata/tm70+gdata/xp65+gdata/vk83
 
-# Input files - Using the environment variables passed via -v
-INPUT_HGRID=$INPUT_HGRID
-INPUT_VGRID=$INPUT_VGRID
-INPUT_GBCO=$INPUT_GBCO
+# Input files
+INPUT_HGRID='/g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.25km/2025.09.02/ocean_hgrid.nc'
+INPUT_VGRID='/g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc'
+INPUT_GEBCO='/g/data/ik11/inputs/GEBCO_2024/GEBCO_2024.nc'
+
 # Minimum allowed y-size for a cell (in m)
 CUTOFF_VALUE=6000
+
 # Output filenames
 ESMF_MESH_FILE='access-om3-25km-ESMFmesh.nc'
 ESMF_NO_MASK_MESH_FILE='access-om3-25km-nomask-ESMFmesh.nc'
@@ -32,7 +34,7 @@ set -e #exit on error
 # Copy and link input files
 cp -L --preserve=timestamps "$INPUT_HGRID" ./ocean_hgrid.nc
 cp -L --preserve=timestamps "$INPUT_VGRID" ./ocean_vgrid.nc
-ln -sf "$INPUT_GBCO" ./GEBCO_2024.nc
+ln -sf "$INPUT_GEBCO" ./GEBCO_2024.nc
 
 # Convert double precision vgrid to single
 ./bathymetry-tools/bin/float_vgrid --vgrid ocean_vgrid.nc --vgrid_type mom6
@@ -62,8 +64,8 @@ MD5SUM=$(md5sum $INPUT_HGRID | awk '{print $1}')
 ncatted -O -h -a input_file,global,a,c,"$(readlink -f $INPUT_HGRID) (md5sum:$MD5SUM) ; " topog.nc
 MD5SUM=$(md5sum "$INPUT_VGRID" | awk '{print $1}')
 ncatted -O -h -a input_file,global,a,c,"$(readlink -f $INPUT_VGRID) (md5sum:$MD5SUM) ; " topog.nc
-MD5SUM=$(md5sum $INPUT_GBCO | awk '{print $1}')
-ncatted -O -h -a input_file,global,a,c,"$(readlink -f $INPUT_GBCO) (md5sum:$MD5SUM) ; " topog.nc
+MD5SUM=$(md5sum $INPUT_GEBCO | awk '{print $1}')
+ncatted -O -h -a input_file,global,a,c,"$(readlink -f $INPUT_GEBCO) (md5sum:$MD5SUM) ; " topog.nc
 
 #Move intermediate files to a separate directory
 OUTPUT_DIR="topography_intermediate_output"


### PR DESCRIPTION
Specify input files directly in `gen_topo.sh` rather than via environment variables, so that full provenance is preserved in the git commit appended to the file by `finalise.sh`